### PR TITLE
inline code blocks breaking lists so hacked

### DIFF
--- a/_episodes/16-writing-functions.md
+++ b/_episodes/16-writing-functions.md
@@ -201,7 +201,7 @@ result of call is: None
 
 > ## Order of Operations
 >
-> 1. What's wrong in this example?
+> &nbsp;1. What's wrong in this example?
 >
 > ~~~
 > result = print_date(1871,3,19)
@@ -212,7 +212,7 @@ result of call is: None
 > ~~~
 > {: .language-python}
 > 
-> 2. After fixing print_date(), explain why running this example code:
+> &nbsp;2. After fixing the problem above, explain why running this example code:
 >
 > ~~~
 > result = print_date(1871, 3, 19)
@@ -220,7 +220,7 @@ result of call is: None
 > ~~~
 > {: .language-python}
 >
-> gives this output?
+> gives this output:
 >
 > ~~~
 > 1871/3/19
@@ -228,7 +228,7 @@ result of call is: None
 > ~~~
 > {: .output}
 >
-> 3. Why is the result of the call `None`?
+> &nbsp;3. Why is the result of the call `None`?
 >
 > > ## Solution
 > > 


### PR DESCRIPTION
https://github.com/jekyll/jekyll/issues/588. - inserting code blocks in between elements of a list cause the numbering to start over.

There is a solution involving indenting the code blocks, but I chose to hardcode the list numbers instead, since they aren't likely to change.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
